### PR TITLE
Add ML algorithms comparison script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,24 @@
+# Kaggle Example
 
+This repository contains a simple Python script that demonstrates how to try different machine learning algorithms on the Iris dataset using scikit-learn.
+
+## Requirements
+- Python 3.11
+- scikit-learn
+- pandas
+- numpy
+
+Install dependencies with:
+
+```bash
+pip install scikit-learn pandas numpy
+```
+
+## Usage
+Run the script:
+
+```bash
+python3 ml_algorithms.py
+```
+
+The script will train and evaluate several algorithms and output their accuracy.

--- a/ml_algorithms.py
+++ b/ml_algorithms.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+from sklearn.linear_model import LogisticRegression
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.svm import SVC
+from sklearn.neighbors import KNeighborsClassifier
+
+
+def load_data():
+    """Load a sample dataset (Iris)"""
+    iris = datasets.load_iris()
+    X = iris.data
+    y = iris.target
+    return train_test_split(X, y, test_size=0.3, random_state=42)
+
+
+def evaluate_model(model, X_train, X_test, y_train, y_test):
+    model.fit(X_train, y_train)
+    predictions = model.predict(X_test)
+    return accuracy_score(y_test, predictions)
+
+
+if __name__ == "__main__":
+    X_train, X_test, y_train, y_test = load_data()
+
+    models = {
+        "Logistic Regression": LogisticRegression(max_iter=200),
+        "Decision Tree": DecisionTreeClassifier(),
+        "Random Forest": RandomForestClassifier(),
+        "Support Vector Machine": SVC(),
+        "KNN": KNeighborsClassifier(),
+    }
+
+    for name, model in models.items():
+        score = evaluate_model(model, X_train, X_test, y_train, y_test)
+        print(f"{name} Accuracy: {score:.2f}")


### PR DESCRIPTION
## Summary
- add ml_algorithms.py to try logistic regression, decision tree, random forest, SVM, and KNN on the Iris dataset
- document setup and usage in README

## Testing
- `python3 ml_algorithms.py`

------
https://chatgpt.com/codex/tasks/task_e_685563e5dad8832cbeeaec2f00297c5a